### PR TITLE
MAINT: implement spatial procrustes in terms of linalg procrustes

### DIFF
--- a/scipy/spatial/procrustes.py
+++ b/scipy/spatial/procrustes.py
@@ -160,12 +160,8 @@ def _match_points(mtx1, mtx2):
         of mtx 2.  See procrustes docs for details.
 
     """
-    u, s, vh = np.linalg.svd(np.dot(np.transpose(mtx1), mtx2))
-    q = np.dot(np.transpose(vh), np.transpose(u))
-    new_mtx2 = np.dot(mtx2, q)
-    new_mtx2 *= np.sum(s)
-
-    return new_mtx2
+    R, s = orthogonal_procrustes(mtx1, mtx2)
+    return np.dot(mtx2, R.T) * s
 
 
 def _get_disparity(mtx1, mtx2):

--- a/scipy/spatial/tests/test_procrustes.py
+++ b/scipy/spatial/tests/test_procrustes.py
@@ -37,11 +37,11 @@ class ProcrustesTests(TestCase):
                               'd') / np.sqrt(4)
 
     def test_procrustes(self):
-        """tests procrustes' ability to match two matrices.
-
-        the second matrix is a rotated, shifted, scaled, and mirrored version
-        of the first, in two dimensions only
-        """
+        # tests procrustes' ability to match two matrices.
+        #
+        # the second matrix is a rotated, shifted, scaled, and mirrored version
+        # of the first, in two dimensions only
+        #
         # can shift, mirror, and scale an 'L'?
         a, b, disparity = procrustes(self.data1, self.data2)
         np.testing.assert_allclose(b, a)
@@ -56,7 +56,7 @@ class ProcrustesTests(TestCase):
         #self.assertTrue(disp13 < 0.5 ** 2)
 
     def test_procrustes2(self):
-        """procrustes disparity should not depend on order of matrices"""
+        # procrustes disparity should not depend on order of matrices
         m1, m3, disp13 = procrustes(self.data1, self.data3)
         m3_2, m1_2, disp31 = procrustes(self.data3, self.data1)
         np.testing.assert_almost_equal(disp13, disp31)


### PR DESCRIPTION
Here's a small change, restoring the use of the `orthogonal_procrustes` function.  It also changes some test docstrings to comments, following scipy style.
